### PR TITLE
fix: internal anchor navigation for non-ASCII headings and footnotes

### DIFF
--- a/src/components/editor/MarkdownViewer.tsx
+++ b/src/components/editor/MarkdownViewer.tsx
@@ -41,7 +41,7 @@ function handleLinkClick(e: MouseEvent) {
   }
 
   if (href.startsWith('#')) {
-    const id = href.slice(1);
+    const id = decodeURIComponent(href.slice(1));
     document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
     return;
   }

--- a/src/lib/editor/render-markdown.ts
+++ b/src/lib/editor/render-markdown.ts
@@ -11,6 +11,7 @@ import { codeToHtml, type BundledTheme } from 'shiki';
 // Extend default sanitization schema to allow KaTeX and code block classes
 const sanitizeSchema = {
   ...defaultSchema,
+  clobberPrefix: '',
   attributes: {
     ...defaultSchema.attributes,
     code: [...(defaultSchema.attributes?.code ?? []), 'className'],


### PR DESCRIPTION
Two issues fixed:
- URL-decode anchor href before getElementById lookup, fixing navigation to Chinese/non-ASCII headings where href is URL-encoded but id is raw text
- Disable rehype-sanitize clobberPrefix to prevent double-prefixing of footnote IDs (remark-gfm already adds user-content- prefix)

Closes #9

https://claude.ai/code/session_016GkWFDa9uijsakaaGUCrk3