### PR TITLE
feat: add line numbers to markdown edit mode

### DIFF
--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -1,5 +1,5 @@
 import { createCodeMirror, createEditorControlledValue } from 'solid-codemirror';
-import { EditorView, keymap } from '@codemirror/view';
+import { EditorView, keymap, lineNumbers } from '@codemirror/view';
 import { markdown } from '@codemirror/lang-markdown';
 import { defaultKeymap, indentWithTab } from '@codemirror/commands';
 import { content, setContent } from '~/stores/editor';
@@ -15,6 +15,7 @@ export function MarkdownEditor() {
     ...catppuccinTheme,
     keymap.of([indentWithTab, ...defaultKeymap]),
     EditorView.lineWrapping,
+    lineNumbers(),
   ]);
 
   createEditorControlledValue(editorView, () => content());

--- a/src/lib/editor/codemirror-theme.ts
+++ b/src/lib/editor/codemirror-theme.ts
@@ -23,7 +23,17 @@ const theme = EditorView.theme({
   '.cm-activeLine': {
     backgroundColor: 'color-mix(in srgb, var(--ctp-surface0) 30%, transparent)',
   },
-  '.cm-gutters': { display: 'none' },
+  '.cm-gutters': {
+    backgroundColor: 'transparent',
+    color: 'var(--ctp-overlay0)',
+    border: 'none',
+  },
+  '.cm-lineNumbers .cm-gutterElement': {
+    paddingLeft: '0.5rem',
+    paddingRight: '0.75rem',
+    fontSize: '0.85em',
+    minWidth: '2.5rem',
+  },
   '&.cm-focused': { outline: 'none' },
 });
 


### PR DESCRIPTION
Enable CodeMirror lineNumbers() extension and style the gutter to match the Catppuccin theme with transparent background and subtle text color. Only applies to edit mode; preview mode is unaffected.

Closes #5 (行号展示)

https://claude.ai/code/session_016GkWFDa9uijsakaaGUCrk3