### PR TITLE
Add file search functionality to FileListPane

### DIFF
--- a/src/components/layout/FileListPane.tsx
+++ b/src/components/layout/FileListPane.tsx
@@ -7,6 +7,9 @@ import {
   selectFile,
   openSingleFile,
   toggleFolder,
+  searchQuery,
+  setSearchQuery,
+  searchMarkdownFiles,
 } from '~/stores/workspace';
 import type { FileNode } from '~/types/file-tree';
 import { loadFile } from '~/stores/editor';
@@ -17,6 +20,8 @@ import FolderOpen from 'lucide-solid/icons/folder-open';
 import ChevronDown from 'lucide-solid/icons/chevron-down';
 import ChevronRight from 'lucide-solid/icons/chevron-right';
 import Folder from 'lucide-solid/icons/folder';
+import Search from 'lucide-solid/icons/search';
+import X from 'lucide-solid/icons/x';
 
 // --- Helpers ---
 
@@ -186,6 +191,7 @@ export function FileListPane() {
 
   const mdFiles = createMemo(() => collectMarkdownFiles(null));
   const fileCount = createMemo(() => mdFiles().length);
+  const filteredFiles = createMemo(() => searchMarkdownFiles(searchQuery()));
 
   const handleFileClick = (path: string) => {
     selectFile(path);
@@ -232,6 +238,34 @@ export function FileListPane() {
         </div>
       </div>
 
+      {/* Search box */}
+      <Show when={workspaceState.workspacePath}>
+        <div class="px-2 pb-1 shrink-0">
+          <div
+            class="flex items-center gap-1.5 px-2 py-1 rounded-md"
+            style={{ background: 'var(--ctp-surface0)' }}
+          >
+            <Search size={14} style={{ color: 'var(--ctp-overlay1)', 'flex-shrink': '0' }} />
+            <input
+              type="text"
+              placeholder={t('searchPlaceholder')}
+              value={searchQuery()}
+              onInput={(e) => setSearchQuery(e.currentTarget.value)}
+              class="flex-1 bg-transparent text-xs outline-none min-w-0"
+              style={{ color: 'var(--ctp-text)' }}
+            />
+            <Show when={searchQuery()}>
+              <button
+                class="flex items-center justify-center rounded hover:bg-surface1/50 transition-colors"
+                onClick={() => setSearchQuery('')}
+              >
+                <X size={12} style={{ color: 'var(--ctp-overlay1)' }} />
+              </button>
+            </Show>
+          </div>
+        </div>
+      </Show>
+
       {/* File tree */}
       <div class="flex-1 overflow-y-auto">
         <Show
@@ -242,18 +276,45 @@ export function FileListPane() {
             </div>
           }
         >
-          <div class="pt-1 flex flex-col gap-0.5">
-            <For each={workspaceState.tree}>
-              {(node) => (
-                <TreeNode
-                  node={node}
-                  depth={0}
-                  selectedFile={workspaceState.selectedFile}
-                  onFileClick={handleFileClick}
-                />
-              )}
-            </For>
-          </div>
+          <Show
+            when={searchQuery()}
+            fallback={
+              <div class="pt-1 flex flex-col gap-0.5">
+                <For each={workspaceState.tree}>
+                  {(node) => (
+                    <TreeNode
+                      node={node}
+                      depth={0}
+                      selectedFile={workspaceState.selectedFile}
+                      onFileClick={handleFileClick}
+                    />
+                  )}
+                </For>
+              </div>
+            }
+          >
+            <Show
+              when={filteredFiles().length > 0}
+              fallback={
+                <div class="px-3 py-8 text-xs text-overlay0 text-center">
+                  {t('noResults')}
+                </div>
+              }
+            >
+              <div class="pt-1 flex flex-col gap-0.5">
+                <For each={filteredFiles()}>
+                  {(file) => (
+                    <TreeFileItem
+                      file={file}
+                      depth={0}
+                      isActive={workspaceState.selectedFile === file.path}
+                      onClick={handleFileClick}
+                    />
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
         </Show>
       </div>
     </div>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -61,6 +61,8 @@ const messages: Record<Locale, Record<string, string>> = {
     lines: '行数',
     resetConfig: '重置配置',
     confirmReset: '确认重置',
+    searchPlaceholder: '搜索笔记…',
+    noResults: '无匹配结果',
   },
   'zh-TW': {
     appName: '皮蛋記',
@@ -114,6 +116,8 @@ const messages: Record<Locale, Record<string, string>> = {
     lines: '行數',
     resetConfig: '重置設定',
     confirmReset: '確認重置',
+    searchPlaceholder: '搜尋筆記…',
+    noResults: '無匹配結果',
   },
   'en-US': {
     appName: 'PiDanMD',
@@ -167,6 +171,8 @@ const messages: Record<Locale, Record<string, string>> = {
     lines: 'Lines',
     resetConfig: 'Reset Settings',
     confirmReset: 'Confirm Reset',
+    searchPlaceholder: 'Search notes…',
+    noResults: 'No results',
   },
   'ja-JP': {
     appName: 'PiDanMD',
@@ -220,6 +226,8 @@ const messages: Record<Locale, Record<string, string>> = {
     lines: '行数',
     resetConfig: '設定をリセット',
     confirmReset: 'リセットを確認',
+    searchPlaceholder: 'ノートを検索…',
+    noResults: '結果なし',
   },
   'ko-KR': {
     appName: 'PiDanMD',
@@ -273,6 +281,8 @@ const messages: Record<Locale, Record<string, string>> = {
     lines: '줄 수',
     resetConfig: '설정 초기화',
     confirmReset: '초기화 확인',
+    searchPlaceholder: '노트 검색…',
+    noResults: '결과 없음',
   },
 };
 

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -135,6 +135,19 @@ function selectFile(path: string) {
 
 const [selectedFolder, setSelectedFolder] = createSignal<string | null>(null);
 
+const [searchQuery, setSearchQuery] = createSignal('');
+
+function searchMarkdownFiles(query: string): FileNode[] {
+  if (!query.trim()) return [];
+  const q = query.toLowerCase();
+  const allFiles = collectMarkdownFiles(null);
+  return allFiles.filter((f) => {
+    const nameMatch = f.name.toLowerCase().includes(q);
+    const titleMatch = f.title?.toLowerCase().includes(q);
+    return nameMatch || titleMatch;
+  });
+}
+
 function selectFolder(path: string | null) {
   setSelectedFolder(path);
 }
@@ -298,5 +311,8 @@ export {
   collectMarkdownFiles,
   collectMarkdownFilesByGroup,
   openSingleFile,
+  searchQuery,
+  setSearchQuery,
+  searchMarkdownFiles,
 };
 export type { FileGroup };


### PR DESCRIPTION
## Summary
This PR adds a search feature to the file list pane, allowing users to quickly filter and find markdown notes by filename or title.

## Key Changes
- **Search UI Component**: Added a search input box in the FileListPane with a search icon and clear button that appears when a workspace is loaded
- **Search Logic**: Implemented `searchMarkdownFiles()` function in the workspace store that filters markdown files by matching against both filename and title (case-insensitive)
- **State Management**: Added `searchQuery` signal and `setSearchQuery` setter to manage search input state
- **Conditional Rendering**: Modified file tree display to show search results when a query is active, with a fallback to the normal tree view when search is empty
- **Empty State**: Added "no results" message when search returns no matches
- **Internationalization**: Added search-related i18n strings for Chinese (Simplified & Traditional), English, Japanese, and Korean locales

## Implementation Details
- Search filters files using `collectMarkdownFiles()` to get all markdown files, then applies the query filter
- Search matches against both `name` and `title` properties of FileNode objects
- Uses Solid.js `Show` component to conditionally render search results vs. normal tree view
- Clear button only appears when search query is non-empty
- Search results are displayed as a flat list using the existing `TreeFileItem` component

https://claude.ai/code/session_01JWXEMJJ43HEJgKPT8z8pMc