### PR TITLE
feat: add file rename and delete via context menu

### DIFF
--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -134,6 +134,23 @@ pub fn copy_file(
 }
 
 #[tauri::command]
+pub fn rename_entry(old_path: String, new_path: String, state: State<Mutex<AppState>>) -> Result<(), String> {
+    let safe_old = validate_path(&old_path, &state)?;
+    let safe_new = validate_path(&new_path, &state)?;
+    fs::rename(&safe_old, &safe_new).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_entry(path: String, is_directory: bool, state: State<Mutex<AppState>>) -> Result<(), String> {
+    let safe_path = validate_path(&path, &state)?;
+    if is_directory {
+        fs::remove_dir_all(&safe_path).map_err(|e| e.to_string())
+    } else {
+        fs::remove_file(&safe_path).map_err(|e| e.to_string())
+    }
+}
+
+#[tauri::command]
 pub fn get_default_storage_dir(app: tauri::AppHandle) -> Result<String, String> {
     let data_dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
     let storage = data_dir.join("workspace");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,8 @@ pub fn run() {
             commands::fs::create_directory,
             commands::fs::write_binary_file,
             commands::fs::copy_file,
+            commands::fs::rename_entry,
+            commands::fs::delete_entry,
             commands::fs::get_default_storage_dir,
             commands::workspace::open_workspace,
             commands::fonts::list_system_fonts,

--- a/src/components/layout/FileListPane.tsx
+++ b/src/components/layout/FileListPane.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo, onMount } from 'solid-js';
+import { For, Show, createMemo, createSignal, onMount } from 'solid-js';
 import { fileListVisible } from '~/stores/layout';
 import {
   workspaceState,
@@ -6,6 +6,8 @@ import {
   collectMarkdownFiles,
   selectFile,
   toggleFolder,
+  renameNode,
+  deleteNode,
   searchQuery,
   setSearchQuery,
   searchMarkdownFiles,
@@ -15,9 +17,9 @@ import {
   confirmCreatingFile,
 } from '~/stores/workspace';
 import type { FileNode } from '~/types/file-tree';
-import { loadFile } from '~/stores/editor';
+import { loadFile, filePath as editorFilePath, clearEditor, setFilePath } from '~/stores/editor';
 import { open } from '@tauri-apps/plugin-dialog';
-import { t, locale } from '~/lib/i18n';
+import { t, tWith, noteCount, locale } from '~/lib/i18n';
 import FileText from 'lucide-solid/icons/file-text';
 import FilePlus from 'lucide-solid/icons/file-plus';
 import FolderOpen from 'lucide-solid/icons/folder-open';
@@ -26,6 +28,7 @@ import ChevronRight from 'lucide-solid/icons/chevron-right';
 import Folder from 'lucide-solid/icons/folder';
 import Search from 'lucide-solid/icons/search';
 import X from 'lucide-solid/icons/x';
+import { ContextMenu } from '~/components/sidebar/ContextMenu';
 
 // --- Helpers ---
 
@@ -106,32 +109,66 @@ function TreeFileItem(props: {
   depth: number;
   isActive: boolean;
   onClick: (path: string) => void;
+  onContextMenu: (e: MouseEvent, node: FileNode) => void;
+  isRenaming: boolean;
+  renameValue: string;
+  onRenameChange: (v: string) => void;
+  onRenameConfirm: () => void;
+  onRenameCancel: () => void;
 }) {
   const displayName = () => props.file.name.replace(/\.md$/, '');
   const displayTitle = () => props.file.title || displayName();
 
   return (
-    <button
-      class="w-full text-left rounded-md px-2 py-1.5 transition-colors focus-visible:ring-1 focus-visible:ring-overlay1 focus-visible:outline-none file-item"
-      style={{
-        'padding-left': `${props.depth * 16 + 8}px`,
-        background: props.isActive
-          ? 'color-mix(in srgb, var(--ctp-overlay1) 15%, transparent)'
-          : 'transparent',
-      }}
-      classList={{ 'file-item-active': props.isActive }}
-      onClick={() => props.onClick(props.file.path)}
+    <Show
+      when={!props.isRenaming}
+      fallback={
+        <div
+          class="w-full px-2 py-1.5"
+          style={{ 'padding-left': `${props.depth * 16 + 8}px` }}
+        >
+          <input
+            ref={(el) => setTimeout(() => el.focus(), 0)}
+            class="w-full text-sm rounded px-1 py-0.5 outline-none"
+            style={{
+              background: 'var(--ctp-surface1)',
+              color: 'var(--ctp-text)',
+              border: '1px solid var(--ctp-overlay0)',
+            }}
+            value={props.renameValue}
+            onInput={(e) => props.onRenameChange(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') props.onRenameConfirm();
+              if (e.key === 'Escape') props.onRenameCancel();
+            }}
+            onBlur={() => props.onRenameConfirm()}
+          />
+        </div>
+      }
     >
-      <div
-        class="text-sm truncate font-medium"
-        style={{ color: props.isActive ? 'var(--ctp-text)' : 'var(--ctp-subtext0)' }}
+      <button
+        class="w-full text-left rounded-md px-2 py-1.5 transition-colors focus-visible:ring-1 focus-visible:ring-overlay1 focus-visible:outline-none file-item"
+        style={{
+          'padding-left': `${props.depth * 16 + 8}px`,
+          background: props.isActive
+            ? 'color-mix(in srgb, var(--ctp-overlay1) 15%, transparent)'
+            : 'transparent',
+        }}
+        classList={{ 'file-item-active': props.isActive }}
+        onClick={() => props.onClick(props.file.path)}
+        onContextMenu={(e) => props.onContextMenu(e, props.file)}
       >
-        {displayTitle()}
-      </div>
-      <div class="text-xs truncate" style={{ color: 'var(--ctp-overlay0)' }}>
-        {formatDate(props.file.modified)}
-      </div>
-    </button>
+        <div
+          class="text-sm truncate font-medium"
+          style={{ color: props.isActive ? 'var(--ctp-text)' : 'var(--ctp-subtext0)' }}
+        >
+          {displayTitle()}
+        </div>
+        <div class="text-xs truncate" style={{ color: 'var(--ctp-overlay0)' }}>
+          {formatDate(props.file.modified)}
+        </div>
+      </button>
+    </Show>
   );
 }
 
@@ -139,26 +176,61 @@ function TreeFolderItem(props: {
   node: FileNode;
   depth: number;
   onToggle: () => void;
+  onContextMenu: (e: MouseEvent, node: FileNode) => void;
+  isRenaming: boolean;
+  renameValue: string;
+  onRenameChange: (v: string) => void;
+  onRenameConfirm: () => void;
+  onRenameCancel: () => void;
 }) {
   const mdCount = () => countMdFiles(props.node.children);
 
   return (
-    <button
-      class="w-full text-left rounded-md px-2 py-1 flex items-center gap-1 select-none hover:bg-surface0/50 transition-colors"
-      style={{ 'padding-left': `${props.depth * 16 + 8}px` }}
-      onClick={props.onToggle}
+    <Show
+      when={!props.isRenaming}
+      fallback={
+        <div
+          class="w-full px-2 py-1 flex items-center gap-1"
+          style={{ 'padding-left': `${props.depth * 16 + 8}px` }}
+        >
+          <Folder size={14} style={{ color: 'var(--ctp-subtext0)', 'flex-shrink': '0' }} />
+          <input
+            ref={(el) => setTimeout(() => el.focus(), 0)}
+            class="flex-1 text-xs font-semibold rounded px-1 py-0.5 outline-none min-w-0"
+            style={{
+              background: 'var(--ctp-surface1)',
+              color: 'var(--ctp-text)',
+              border: '1px solid var(--ctp-overlay0)',
+            }}
+            value={props.renameValue}
+            onInput={(e) => props.onRenameChange(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') props.onRenameConfirm();
+              if (e.key === 'Escape') props.onRenameCancel();
+            }}
+            onBlur={() => props.onRenameConfirm()}
+          />
+        </div>
+      }
     >
-      <Show when={props.node.isExpanded} fallback={<ChevronRight size={14} style={{ color: 'var(--ctp-subtext0)', 'flex-shrink': '0' }} />}>
-        <ChevronDown size={14} style={{ color: 'var(--ctp-subtext0)', 'flex-shrink': '0' }} />
-      </Show>
-      <Folder size={14} style={{ color: 'var(--ctp-subtext0)', 'flex-shrink': '0' }} />
-      <span class="text-xs font-semibold truncate" style={{ color: 'var(--ctp-subtext1)' }}>
-        {props.node.name}
-      </span>
-      <span class="text-xs ml-auto flex-shrink-0" style={{ color: 'var(--ctp-overlay0)' }}>
-        {mdCount()}
-      </span>
-    </button>
+      <button
+        class="w-full text-left rounded-md px-2 py-1 flex items-center gap-1 select-none hover:bg-surface0/50 transition-colors"
+        style={{ 'padding-left': `${props.depth * 16 + 8}px` }}
+        onClick={props.onToggle}
+        onContextMenu={(e) => props.onContextMenu(e, props.node)}
+      >
+        <Show when={props.node.isExpanded} fallback={<ChevronRight size={14} style={{ color: 'var(--ctp-subtext0)', 'flex-shrink': '0' }} />}>
+          <ChevronDown size={14} style={{ color: 'var(--ctp-subtext0)', 'flex-shrink': '0' }} />
+        </Show>
+        <Folder size={14} style={{ color: 'var(--ctp-subtext0)', 'flex-shrink': '0' }} />
+        <span class="text-xs font-semibold truncate" style={{ color: 'var(--ctp-subtext1)' }}>
+          {props.node.name}
+        </span>
+        <span class="text-xs ml-auto flex-shrink-0" style={{ color: 'var(--ctp-overlay0)' }}>
+          {mdCount()}
+        </span>
+      </button>
+    </Show>
   );
 }
 
@@ -167,6 +239,12 @@ function TreeNode(props: {
   depth: number;
   selectedFile: string | null;
   onFileClick: (path: string) => void;
+  onContextMenu: (e: MouseEvent, node: FileNode) => void;
+  renamingPath: string | null;
+  renameValue: string;
+  onRenameChange: (v: string) => void;
+  onRenameConfirm: () => void;
+  onRenameCancel: () => void;
 }) {
   // Skip non-.md files and folders without .md descendants
   if (!hasMdFiles(props.node)) return null;
@@ -179,6 +257,12 @@ function TreeNode(props: {
         depth={props.depth}
         isActive={props.selectedFile === props.node.path}
         onClick={props.onFileClick}
+        onContextMenu={props.onContextMenu}
+        isRenaming={props.renamingPath === props.node.path}
+        renameValue={props.renameValue}
+        onRenameChange={props.onRenameChange}
+        onRenameConfirm={props.onRenameConfirm}
+        onRenameCancel={props.onRenameCancel}
       />
     );
   }
@@ -189,6 +273,12 @@ function TreeNode(props: {
         node={props.node}
         depth={props.depth}
         onToggle={() => toggleFolder(props.node.path)}
+        onContextMenu={props.onContextMenu}
+        isRenaming={props.renamingPath === props.node.path}
+        renameValue={props.renameValue}
+        onRenameChange={props.onRenameChange}
+        onRenameConfirm={props.onRenameConfirm}
+        onRenameCancel={props.onRenameCancel}
       />
       <Show when={props.node.isExpanded}>
         <Show when={props.node.isLoading}>
@@ -207,6 +297,12 @@ function TreeNode(props: {
                 depth={props.depth + 1}
                 selectedFile={props.selectedFile}
                 onFileClick={props.onFileClick}
+                onContextMenu={props.onContextMenu}
+                renamingPath={props.renamingPath}
+                renameValue={props.renameValue}
+                onRenameChange={props.onRenameChange}
+                onRenameConfirm={props.onRenameConfirm}
+                onRenameCancel={props.onRenameCancel}
               />
             )}
           </For>
@@ -222,6 +318,11 @@ function TreeNode(props: {
 // --- Main component ---
 
 export function FileListPane() {
+  const [contextMenu, setContextMenu] = createSignal<{ x: number; y: number; node: FileNode } | null>(null);
+  const [renamingPath, setRenamingPath] = createSignal<string | null>(null);
+  const [renameValue, setRenameValue] = createSignal('');
+  const [deleteTarget, setDeleteTarget] = createSignal<FileNode | null>(null);
+
   const handleOpen = async () => {
     try {
       const selected = await open({ directory: true });
@@ -239,6 +340,66 @@ export function FileListPane() {
   const handleFileClick = (path: string) => {
     selectFile(path);
     loadFile(path);
+  };
+
+  const handleContextMenu = (e: MouseEvent, node: FileNode) => {
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY, node });
+  };
+
+  const handleStartRename = () => {
+    const menu = contextMenu();
+    if (!menu) return;
+    setRenamingPath(menu.node.path);
+    setRenameValue(menu.node.name);
+  };
+
+  const handleRenameConfirm = async () => {
+    const path = renamingPath();
+    if (!path) return;
+    const newName = renameValue().trim();
+    if (!newName || newName === path.split('/').pop()) {
+      setRenamingPath(null);
+      return;
+    }
+    try {
+      const currentEditorPath = editorFilePath();
+      const newPath = await renameNode(path, newName);
+      // Sync editor state
+      if (currentEditorPath === path) {
+        setFilePath(newPath);
+      } else if (currentEditorPath?.startsWith(path + '/')) {
+        setFilePath(currentEditorPath.replace(path, newPath));
+      }
+    } catch (e) {
+      console.error('Failed to rename:', e);
+    }
+    setRenamingPath(null);
+  };
+
+  const handleRenameCancel = () => {
+    setRenamingPath(null);
+  };
+
+  const handleStartDelete = () => {
+    const menu = contextMenu();
+    if (!menu) return;
+    setDeleteTarget(menu.node);
+  };
+
+  const handleDeleteConfirm = async () => {
+    const target = deleteTarget();
+    if (!target) return;
+    try {
+      const currentEditorPath = editorFilePath();
+      const shouldClear = currentEditorPath === target.path
+        || (target.isDirectory && currentEditorPath?.startsWith(target.path + '/'));
+      await deleteNode(target.path, target.isDirectory);
+      if (shouldClear) clearEditor();
+    } catch (e) {
+      console.error('Failed to delete:', e);
+    }
+    setDeleteTarget(null);
   };
 
   return (
@@ -320,6 +481,12 @@ export function FileListPane() {
                       depth={0}
                       selectedFile={workspaceState.selectedFile}
                       onFileClick={handleFileClick}
+                      onContextMenu={handleContextMenu}
+                      renamingPath={renamingPath()}
+                      renameValue={renameValue()}
+                      onRenameChange={setRenameValue}
+                      onRenameConfirm={handleRenameConfirm}
+                      onRenameCancel={handleRenameCancel}
                     />
                   )}
                 </For>
@@ -345,6 +512,12 @@ export function FileListPane() {
                       depth={0}
                       isActive={workspaceState.selectedFile === file.path}
                       onClick={handleFileClick}
+                      onContextMenu={handleContextMenu}
+                      isRenaming={renamingPath() === file.path}
+                      renameValue={renameValue()}
+                      onRenameChange={setRenameValue}
+                      onRenameConfirm={handleRenameConfirm}
+                      onRenameCancel={handleRenameCancel}
                     />
                   )}
                 </For>
@@ -353,6 +526,59 @@ export function FileListPane() {
           </Show>
         </Show>
       </div>
+
+      {/* Context menu */}
+      <Show when={contextMenu()}>
+        {(menu) => (
+          <ContextMenu
+            x={menu().x}
+            y={menu().y}
+            onRename={handleStartRename}
+            onDelete={handleStartDelete}
+            onClose={() => setContextMenu(null)}
+          />
+        )}
+      </Show>
+
+      {/* Delete confirmation modal */}
+      <Show when={deleteTarget()}>
+        {(target) => (
+          <div
+            class="fixed inset-0 z-50 flex items-center justify-center"
+            style={{ background: 'rgba(0,0,0,0.5)' }}
+            onClick={() => setDeleteTarget(null)}
+          >
+            <div
+              class="rounded-xl p-5 shadow-xl max-w-xs w-full"
+              style={{ background: 'var(--ctp-base)', border: '1px solid var(--ctp-surface1)' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 class="text-sm font-semibold mb-2" style={{ color: 'var(--ctp-text)' }}>
+                {t('confirmDelete')}
+              </h3>
+              <p class="text-xs mb-4" style={{ color: 'var(--ctp-subtext0)' }}>
+                {tWith('deleteConfirmMessage', { name: target().name })}
+              </p>
+              <div class="flex justify-end gap-2">
+                <button
+                  class="px-3 py-1.5 text-xs rounded-md transition-colors"
+                  style={{ background: 'var(--ctp-surface0)', color: 'var(--ctp-text)' }}
+                  onClick={() => setDeleteTarget(null)}
+                >
+                  {t('cancel')}
+                </button>
+                <button
+                  class="px-3 py-1.5 text-xs rounded-md transition-colors"
+                  style={{ background: 'var(--ctp-red)', color: 'var(--ctp-base)' }}
+                  onClick={handleDeleteConfirm}
+                >
+                  {t('delete')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </Show>
     </div>
   );
 }

--- a/src/components/sidebar/ContextMenu.tsx
+++ b/src/components/sidebar/ContextMenu.tsx
@@ -1,0 +1,70 @@
+import { onCleanup, onMount } from 'solid-js';
+import { t } from '~/lib/i18n';
+import Pencil from 'lucide-solid/icons/pencil';
+import Trash2 from 'lucide-solid/icons/trash-2';
+
+interface ContextMenuProps {
+  x: number;
+  y: number;
+  onRename: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export function ContextMenu(props: ContextMenuProps) {
+  let menuRef!: HTMLDivElement;
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (menuRef && !menuRef.contains(e.target as Node)) {
+      props.onClose();
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') props.onClose();
+  };
+
+  onMount(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener('mousedown', handleClickOutside);
+    document.removeEventListener('keydown', handleKeyDown);
+  });
+
+  return (
+    <div
+      ref={menuRef}
+      class="fixed z-50 py-1 rounded-lg shadow-lg min-w-[140px]"
+      style={{
+        left: `${props.x}px`,
+        top: `${props.y}px`,
+        background: 'var(--ctp-surface0)',
+        border: '1px solid var(--ctp-surface1)',
+      }}
+    >
+      <button
+        class="w-full px-3 py-1.5 text-xs text-left flex items-center gap-2 transition-colors"
+        style={{ color: 'var(--ctp-text)' }}
+        onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+        onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+        onClick={() => { props.onRename(); props.onClose(); }}
+      >
+        <Pencil size={14} />
+        {t('rename')}
+      </button>
+      <button
+        class="w-full px-3 py-1.5 text-xs text-left flex items-center gap-2 transition-colors"
+        style={{ color: 'var(--ctp-red)' }}
+        onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+        onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+        onClick={() => { props.onDelete(); props.onClose(); }}
+      >
+        <Trash2 size={14} />
+        {t('delete')}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -67,6 +67,11 @@ const messages: Record<Locale, Record<string, string>> = {
     tools: '展开工具',
     copyToClipboard: '复制文本',
     copied: '已复制',
+    rename: '重命名',
+    delete: '删除',
+    confirmDelete: '确认删除',
+    deleteConfirmMessage: '确定要删除「{name}」吗？',
+    cancel: '取消',
   },
   'zh-TW': {
     appName: '皮蛋記',
@@ -126,6 +131,11 @@ const messages: Record<Locale, Record<string, string>> = {
     tools: '展開工具',
     copyToClipboard: '複製文本',
     copied: '已複製',
+    rename: '重新命名',
+    delete: '刪除',
+    confirmDelete: '確認刪除',
+    deleteConfirmMessage: '確定要刪除「{name}」嗎？',
+    cancel: '取消',
   },
   'en-US': {
     appName: 'PiDanMD',
@@ -185,6 +195,11 @@ const messages: Record<Locale, Record<string, string>> = {
     tools: 'Tools',
     copyToClipboard: 'Copy Text',
     copied: 'Copied',
+    rename: 'Rename',
+    delete: 'Delete',
+    confirmDelete: 'Confirm Delete',
+    deleteConfirmMessage: 'Delete "{name}"?',
+    cancel: 'Cancel',
   },
   'ja-JP': {
     appName: 'PiDanMD',
@@ -244,6 +259,11 @@ const messages: Record<Locale, Record<string, string>> = {
     tools: 'ツール',
     copyToClipboard: 'テキストをコピー',
     copied: 'コピーしました',
+    rename: '名前を変更',
+    delete: '削除',
+    confirmDelete: '削除を確認',
+    deleteConfirmMessage: '「{name}」を削除しますか？',
+    cancel: 'キャンセル',
   },
   'ko-KR': {
     appName: 'PiDanMD',
@@ -303,6 +323,11 @@ const messages: Record<Locale, Record<string, string>> = {
     tools: '도구',
     copyToClipboard: '텍스트 복사',
     copied: '복사됨',
+    rename: '이름 바꾸기',
+    delete: '삭제',
+    confirmDelete: '삭제 확인',
+    deleteConfirmMessage: '"{name}"을(를) 삭제하시겠습니까？',
+    cancel: '취소',
   },
 };
 
@@ -329,6 +354,14 @@ export function initLocaleFromConfig(config: AppConfig) {
 
 export function t(key: string): string {
   return messages[locale()][key] ?? key;
+}
+
+export function tWith(key: string, vars: Record<string, string>): string {
+  let result = messages[locale()][key] ?? key;
+  for (const [k, v] of Object.entries(vars)) {
+    result = result.replace(`{${k}}`, v);
+  }
+  return result;
 }
 
 // 带数字插值的笔记计数

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -23,6 +23,14 @@ export async function listSystemFonts(): Promise<string[]> {
   return invoke('list_system_fonts');
 }
 
+export async function renameEntry(oldPath: string, newPath: string): Promise<void> {
+  return invoke('rename_entry', { oldPath, newPath });
+}
+
+export async function deleteEntry(path: string, isDirectory: boolean): Promise<void> {
+  return invoke('delete_entry', { path, isDirectory });
+}
+
 export async function createDirectory(path: string): Promise<void> {
   return invoke('create_directory', { path });
 }

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -35,6 +35,12 @@ function toggleEditorMode() {
   setEditorMode((m) => (m === 'preview' ? 'edit' : 'preview'));
 }
 
+function clearEditor() {
+  setContentRaw('');
+  setFilePath(null);
+  setIsDirty(false);
+}
+
 async function saveFile() {
   const path = filePath();
   if (!path) return;
@@ -42,4 +48,4 @@ async function saveFile() {
   setIsDirty(false);
 }
 
-export { content, filePath, isDirty, isLoading, loadFile, setContent, editorMode, toggleEditorMode, saveFile };
+export { content, filePath, isDirty, isLoading, loadFile, setContent, editorMode, toggleEditorMode, saveFile, clearEditor, setFilePath };

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -1,7 +1,7 @@
 import { createSignal } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import type { FileNode } from '~/types/file-tree';
-import { listDirectory, createDirectory, getDefaultStorageDir, readFile, writeFile, openWorkspaceCommand, type FileEntry } from '~/lib/tauri/commands';
+import { listDirectory, createDirectory, getDefaultStorageDir, readFile, writeFile, openWorkspaceCommand, renameEntry, deleteEntry, type FileEntry } from '~/lib/tauri/commands';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 
 interface WorkspaceState {
@@ -121,6 +121,27 @@ async function createFolder(name: string) {
   if (!base) return;
   const fullPath = base + '/' + name;
   await createDirectory(fullPath);
+  await refreshWorkspace();
+}
+
+async function renameNode(oldPath: string, newName: string): Promise<string> {
+  const parentDir = oldPath.substring(0, oldPath.lastIndexOf('/'));
+  const newPath = parentDir + '/' + newName;
+  await renameEntry(oldPath, newPath);
+  if (state.selectedFile === oldPath) setState('selectedFile', newPath);
+  if (state.selectedFile?.startsWith(oldPath + '/')) {
+    setState('selectedFile', state.selectedFile.replace(oldPath, newPath));
+  }
+  await refreshWorkspace();
+  return newPath;
+}
+
+async function deleteNode(path: string, isDirectory: boolean) {
+  await deleteEntry(path, isDirectory);
+  if (state.selectedFile === path) setState('selectedFile', null);
+  if (isDirectory && state.selectedFile?.startsWith(path + '/')) {
+    setState('selectedFile', null);
+  }
   await refreshWorkspace();
 }
 
@@ -383,6 +404,9 @@ export {
   initWorkspace,
   refreshWorkspace,
   createFolder,
+  renameNode,
+  deleteNode,
+  findNode,
   toggleFolder,
   selectFile,
   selectedFolder,


### PR DESCRIPTION
## Summary
- 侧边栏文件树支持右键上下文菜单，提供重命名和删除操作
- 内联重命名：选择"重命名"后文件名变为可编辑 input，Enter/blur 确认，Escape 取消
- 删除确认弹窗：选择"删除"后弹出确认对话框，防止误删
- 编辑器状态同步：删除/重命名当前编辑文件时自动清空编辑器或更新路径
- 5 语言 i18n 支持（zh-CN、zh-TW、en-US、ja-JP、ko-KR）
- 后端 `rename_entry`/`delete_entry` 命令均经过 `validate_path` 校验，防止路径逃逸

## Test plan
- [ ] 右键文件 → 重命名 → 输入新名称 → Enter 确认 → 文件树刷新
- [ ] 右键文件 → 删除 → 确认弹窗 → 确认 → 文件从列表消失
- [ ] 删除当前正在编辑的文件 → 编辑器清空
- [ ] 重命名当前正在编辑的文件 → 编辑器路径更新，内容不变
- [ ] 右键文件夹 → 重命名/删除 → 同上
- [ ] 按 Escape 取消重命名 / 关闭菜单
- [ ] 点击外部关闭上下文菜单

🤖 Generated with [Claude Code](https://claude.com/claude-code)