### PR TITLE
feat: add tools dropdown menu with copy-to-clipboard

### DIFF
--- a/src/components/layout/EditorPane.tsx
+++ b/src/components/layout/EditorPane.tsx
@@ -4,6 +4,7 @@ import { formatMarkdown } from '~/lib/editor/format-markdown';
 import { layoutMode, cycleLayoutMode, type LayoutMode } from '~/stores/layout';
 import { openSettingsWindow } from '~/lib/settings-window';
 import { t } from '~/lib/i18n';
+import { createDropdown } from '~/lib/utils/dropdown';
 import { MarkdownViewer } from '~/components/editor/MarkdownViewer';
 import { MarkdownEditor } from '~/components/editor/MarkdownEditor';
 import { EditorPlaceholder } from '~/components/editor/EditorPlaceholder';
@@ -15,6 +16,8 @@ import Columns2 from 'lucide-solid/icons/columns-2';
 import Columns3 from 'lucide-solid/icons/columns-3';
 import TextAlignStart from 'lucide-solid/icons/text-align-start';
 import ChartColumn from 'lucide-solid/icons/chart-column';
+import ListChevronsUpDown from 'lucide-solid/icons/list-chevrons-up-down';
+import ClipboardCopy from 'lucide-solid/icons/clipboard-copy';
 
 function LayoutIcon(props: { mode: LayoutMode }) {
   return (
@@ -52,40 +55,15 @@ function estimateTokens(text: string): number {
 }
 
 export function EditorPane() {
-  const [statsOpen, setStatsOpen] = createSignal(false);
-  let statsRef: HTMLDivElement | undefined;
+  const stats = createDropdown();
+  const tools = createDropdown();
 
-  function handleStatsClickOutside(e: MouseEvent) {
-    if (statsRef && !statsRef.contains(e.target as Node)) {
-      setStatsOpen(false);
-      stopStatsListening();
-    }
-  }
+  const [copied, setCopied] = createSignal(false);
+  let copiedTimer: ReturnType<typeof setTimeout> | undefined;
 
-  function handleStatsKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
-      setStatsOpen(false);
-      stopStatsListening();
-    }
-  }
-
-  const startStatsListening = () => {
-    document.addEventListener('mousedown', handleStatsClickOutside);
-    document.addEventListener('keydown', handleStatsKeyDown);
-  };
-  const stopStatsListening = () => {
-    document.removeEventListener('mousedown', handleStatsClickOutside);
-    document.removeEventListener('keydown', handleStatsKeyDown);
-  };
-
-  onCleanup(stopStatsListening);
-
-  function toggleStats() {
-    const next = !statsOpen();
-    setStatsOpen(next);
-    if (next) startStatsListening();
-    else stopStatsListening();
-  }
+  onCleanup(() => {
+    if (copiedTimer !== undefined) clearTimeout(copiedTimer);
+  });
 
   const wordCount = () => content().split(/[\s\n]+/).filter(Boolean).length;
   const charCount = () => content().replace(/\s/g, '').length;
@@ -121,15 +99,15 @@ export function EditorPane() {
           >
             <FileType size={16} />
           </button>
-          <div ref={statsRef} class="relative">
+          <div ref={stats.setRef} class="relative">
             <button
               class={btnClass}
-              onClick={toggleStats}
+              onClick={stats.toggle}
               title={t('stats')}
             >
               <ChartColumn size={16} />
             </button>
-            <Show when={statsOpen()}>
+            <Show when={stats.isOpen()}>
               <div class="absolute top-full right-0 mt-1 w-48 rounded-lg border border-surface1 bg-mantle shadow-xl z-50 p-3">
                 <div class="space-y-1.5 text-sm">
                   <div class="flex justify-between"><span class="text-subtext0">{t('words')}</span><span class="text-text">{wordCount()}</span></div>
@@ -137,6 +115,38 @@ export function EditorPane() {
                   <div class="flex justify-between"><span class="text-subtext0">{t('lines')}</span><span class="text-text">{lineCount()}</span></div>
                   <div class="flex justify-between"><span class="text-subtext0">Token</span><span class="text-text">≈ {estimateTokens(content())}</span></div>
                 </div>
+              </div>
+            </Show>
+          </div>
+          <div ref={tools.setRef} class="relative">
+            <button
+              class={btnClass}
+              onClick={tools.toggle}
+              title={t('tools')}
+            >
+              <ListChevronsUpDown size={16} />
+            </button>
+            <Show when={tools.isOpen()}>
+              <div class="absolute top-full right-0 mt-1 rounded-lg border border-surface1 bg-mantle shadow-xl z-50 p-2">
+                <button
+                  class="flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-sm text-text hover:bg-surface0 transition-colors whitespace-nowrap"
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(content());
+                      if (copiedTimer !== undefined) clearTimeout(copiedTimer);
+                      setCopied(true);
+                      copiedTimer = setTimeout(() => {
+                        setCopied(false);
+                        copiedTimer = undefined;
+                      }, 1500);
+                    } catch (e) {
+                      console.error('Copy failed:', e);
+                    }
+                  }}
+                >
+                  <ClipboardCopy size={14} />
+                  <span>{copied() ? t('copied') : t('copyToClipboard')}</span>
+                </button>
               </div>
             </Show>
           </div>

--- a/src/components/settings/controls/FontDropdown.tsx
+++ b/src/components/settings/controls/FontDropdown.tsx
@@ -1,7 +1,8 @@
-import { createSignal, createResource, For, Show, onCleanup } from 'solid-js';
+import { createResource, For, Show } from 'solid-js';
 import { listSystemFonts } from '~/lib/tauri/commands';
 import type { BuiltinFont } from '~/stores/settings';
 import { t } from '~/lib/i18n';
+import { createDropdown } from '~/lib/utils/dropdown';
 import ChevronDown from 'lucide-solid/icons/chevron-down';
 import Check from 'lucide-solid/icons/check';
 
@@ -23,43 +24,11 @@ const [systemFonts] = createResource(async () => {
 });
 
 export function FontDropdown(props: Props) {
-  const [open, setOpen] = createSignal(false);
-  let containerRef: HTMLDivElement | undefined;
-
-  // Close on outside click
-  function handleClickOutside(e: MouseEvent) {
-    if (containerRef && !containerRef.contains(e.target as Node)) {
-      setOpen(false);
-    }
-  }
-
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Escape') setOpen(false);
-  }
-
-  // Mount/unmount listeners
-  const startListening = () => {
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleKeyDown);
-  };
-  const stopListening = () => {
-    document.removeEventListener('mousedown', handleClickOutside);
-    document.removeEventListener('keydown', handleKeyDown);
-  };
-
-  onCleanup(stopListening);
-
-  function toggle() {
-    const next = !open();
-    setOpen(next);
-    if (next) startListening();
-    else stopListening();
-  }
+  const dropdown = createDropdown();
 
   function select(name: string) {
     props.onChange(name);
-    setOpen(false);
-    stopListening();
+    dropdown.close();
   }
 
   // Display label for current value
@@ -69,21 +38,21 @@ export function FontDropdown(props: Props) {
   };
 
   return (
-    <div ref={containerRef} class="relative">
+    <div ref={dropdown.setRef} class="relative">
       <Show when={props.label}><span class="text-sm text-subtext1 mb-2 block">{props.label}</span></Show>
       {/* Trigger button */}
       <button
         class="w-full flex items-center justify-between px-3 py-2 rounded-lg border border-surface1 bg-base hover:bg-surface0/40 focus-visible:ring-1 focus-visible:ring-overlay1 focus-visible:outline-none transition-colors text-sm"
-        onClick={toggle}
-        aria-expanded={open()}
+        onClick={dropdown.toggle}
+        aria-expanded={dropdown.isOpen()}
         aria-haspopup="listbox"
       >
         <span class="text-text truncate">{displayLabel()}</span>
-        <ChevronDown size={12} class="text-subtext0 shrink-0 transition-transform" classList={{ 'rotate-180': open() }} />
+        <ChevronDown size={12} class="text-subtext0 shrink-0 transition-transform" classList={{ 'rotate-180': dropdown.isOpen() }} />
       </button>
 
       {/* Dropdown */}
-      <Show when={open()}>
+      <Show when={dropdown.isOpen()}>
         <div class="absolute z-50 mt-1 w-full max-h-[280px] overflow-y-auto rounded-lg border border-surface1 bg-mantle shadow-xl" role="listbox" aria-label={t('selectFont')}>
           {/* Built-in fonts */}
           <Show when={props.showSystemFonts !== false}>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -64,6 +64,9 @@ const messages: Record<Locale, Record<string, string>> = {
     searchPlaceholder: '搜索笔记…',
     noResults: '无匹配结果',
     newFile: '新建文件',
+    tools: '展开工具',
+    copyToClipboard: '复制文本',
+    copied: '已复制',
   },
   'zh-TW': {
     appName: '皮蛋記',
@@ -120,6 +123,9 @@ const messages: Record<Locale, Record<string, string>> = {
     searchPlaceholder: '搜尋筆記…',
     noResults: '無匹配結果',
     newFile: '新增檔案',
+    tools: '展開工具',
+    copyToClipboard: '複製文本',
+    copied: '已複製',
   },
   'en-US': {
     appName: 'PiDanMD',
@@ -176,6 +182,9 @@ const messages: Record<Locale, Record<string, string>> = {
     searchPlaceholder: 'Search notes…',
     noResults: 'No results',
     newFile: 'New File',
+    tools: 'Tools',
+    copyToClipboard: 'Copy Text',
+    copied: 'Copied',
   },
   'ja-JP': {
     appName: 'PiDanMD',
@@ -232,6 +241,9 @@ const messages: Record<Locale, Record<string, string>> = {
     searchPlaceholder: 'ノートを検索…',
     noResults: '結果なし',
     newFile: '新規ファイル',
+    tools: 'ツール',
+    copyToClipboard: 'テキストをコピー',
+    copied: 'コピーしました',
   },
   'ko-KR': {
     appName: 'PiDanMD',
@@ -288,6 +300,9 @@ const messages: Record<Locale, Record<string, string>> = {
     searchPlaceholder: '노트 검색…',
     noResults: '결과 없음',
     newFile: '새 파일',
+    tools: '도구',
+    copyToClipboard: '텍스트 복사',
+    copied: '복사됨',
   },
 };
 

--- a/src/lib/utils/dropdown.ts
+++ b/src/lib/utils/dropdown.ts
@@ -1,0 +1,40 @@
+import { createSignal, onCleanup } from 'solid-js';
+
+export function createDropdown() {
+  const [isOpen, setIsOpen] = createSignal(false);
+  let ref: HTMLElement | undefined;
+
+  function close() {
+    setIsOpen(false);
+    stop();
+  }
+
+  function handleClickOutside(e: MouseEvent) {
+    if (ref && !ref.contains(e.target as Node)) close();
+  }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape') close();
+  }
+
+  function start() {
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+  }
+
+  function stop() {
+    document.removeEventListener('mousedown', handleClickOutside);
+    document.removeEventListener('keydown', handleKeyDown);
+  }
+
+  function toggle() {
+    const next = !isOpen();
+    setIsOpen(next);
+    if (next) start();
+    else stop();
+  }
+
+  onCleanup(stop);
+
+  return { isOpen, toggle, close, setRef: (el: HTMLElement) => { ref = el; } };
+}


### PR DESCRIPTION
## Summary
- EditorPane 右上角新增"展开工具"下拉菜单，首个工具为"复制文本"（一键复制当前 Markdown 内容到系统剪贴板）
- 提取 `createDropdown()` hook（`src/lib/utils/dropdown.ts`），消除 EditorPane 和 FontDropdown 中的下拉逻辑重复代码
- 添加 `tools` / `copyToClipboard` / `copied` 三个 i18n 翻译键（zh-CN / zh-TW / en-US / ja-JP / ko-KR）

## Test plan
- [ ] `pnpm dev` 启动应用，打开一个 Markdown 文件
- [ ] 确认右上角工具栏出现 `ListChevronsUpDown` 图标按钮
- [ ] 点击按钮弹出工具面板，包含"复制文本"选项
- [ ] 点击"复制文本"，粘贴到其他应用确认内容正确，按钮显示"已复制"反馈
- [ ] 点击面板外部或按 Escape 关闭面板
- [ ] 未打开文件时该按钮不显示
- [ ] 设置页面的字体下拉菜单功能正常（验证 createDropdown hook 重构无回归）

🤖 Generated with [Claude Code](https://claude.com/claude-code)