### PR TITLE
fix: font loading failure + Windows titlebar triple-stacking

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,11 +27,18 @@ pub fn run() {
             commands::config::reset_config,
         ])
         .setup(|app| {
-            let menu = menu::build_menu(app)?;
-            app.set_menu(menu)?;
-            app.on_menu_event(|app, event| {
-                let _ = app.emit("menu-action", event.id().0.as_str());
-            });
+            // Only set native menu on macOS — it lives in the system menu bar
+            // and doesn't consume window space. On Windows/Linux the native
+            // menu would stack below the titlebar creating a large blank area,
+            // so we skip it and rely on keyboard shortcuts + custom UI instead.
+            #[cfg(target_os = "macos")]
+            {
+                let menu = menu::build_menu(app)?;
+                app.set_menu(menu)?;
+                app.on_menu_event(|app, event| {
+                    let _ = app.emit("menu-action", event.id().0.as_str());
+                });
+            }
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src/features/titlebar/TitleBar.tsx
+++ b/src/features/titlebar/TitleBar.tsx
@@ -19,6 +19,8 @@ const layoutIcons: Record<LayoutMode, React.ComponentType<{ className?: string }
   focus: Maximize2,
 };
 
+const isMac = navigator.userAgent.includes("Mac");
+
 export function TitleBar() {
   const t = useT();
   const layoutMode = useAppStore((s) => s.layoutMode);
@@ -28,16 +30,16 @@ export function TitleBar() {
   const filePath = useEditorStore((s) => s.filePath);
 
   const LayoutIcon = layoutIcons[layoutMode];
-  const fileName = filePath ? filePath.split("/").pop() : null;
+  const fileName = filePath ? filePath.split(/[/\\]/).pop() : null;
 
   return (
     <div
       data-tauri-drag-region
       className="flex h-11 items-center justify-between border-b bg-background/80 backdrop-blur-sm px-3 select-none"
     >
-      {/* Left: macOS traffic light spacer */}
+      {/* Left: macOS traffic light spacer / Windows: nothing */}
       <div data-tauri-drag-region className="flex items-center gap-1 min-w-[80px]">
-        <div className="w-[70px]" /> {/* macOS traffic light spacer */}
+        {isMac && <div className="w-[70px]" />}
       </div>
 
       {/* Center: File name */}
@@ -50,7 +52,7 @@ export function TitleBar() {
         )}
       </div>
 
-      {/* Right: Actions */}
+      {/* Right: Actions + Windows system button spacer */}
       <div className="flex items-center gap-0.5">
         <Tooltip content={t("layout")}>
           <Button
@@ -71,6 +73,9 @@ export function TitleBar() {
             <Settings className="h-4 w-4" />
           </Button>
         </Tooltip>
+
+        {/* Windows/Linux: reserve space for native window controls (min/max/close) */}
+        {!isMac && <div className="w-[140px]" />}
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -153,7 +153,7 @@ body {
 
 @font-face {
   font-family: "LXGW WenKai Screen";
-  src: url("/fonts/LXGWWenKaiScreen.woff2") format("woff2");
+  src: url("/fonts/LXGWWenKaiScreen.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -161,7 +161,7 @@ body {
 
 @font-face {
   font-family: "LXGW WenKai Mono Screen";
-  src: url("/fonts/LXGWWenKaiMonoScreen.woff2") format("woff2");
+  src: url("/fonts/LXGWWenKaiMonoScreen.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -169,7 +169,7 @@ body {
 
 @font-face {
   font-family: "Cascadia Code NF";
-  src: url("/fonts/CascadiaCodeNF.woff2") format("woff2");
+  src: url("/fonts/CascadiaCodeNF.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
## Summary

- **Fix font loading**: `@font-face` declarations referenced `.woff2` files but `public/fonts/` only contains `.ttf` — fonts failed to load and fell back to system defaults. Changed to `format("truetype")` with `.ttf` URLs.
- **Fix Windows titlebar**: Three layers were stacking (native titlebar + native menu bar + custom React titlebar), creating a huge blank area. Made native menu macOS-only (`#[cfg(target_os = "macos")]`) and made `TitleBar.tsx` platform-aware with correct spacing for both macOS traffic lights and Windows window controls.

## Test plan

- [ ] Build with `pnpm build` — verify `dist/fonts/` contains all 3 `.ttf` files
- [ ] Install on Windows — verify no blank area at top, window controls (min/max/close) in the same row as custom titlebar
- [ ] Install on macOS — verify native menu bar still works, traffic light buttons aligned correctly
- [ ] Verify bundled fonts (LXGW WenKai, Cascadia Code) render correctly on a clean machine

https://claude.ai/code/session_012zheLeSi6Yq1ZN1nvxmv4b