### PR TITLE
fix: Windows 顶部标题栏布局异常及沉浸式背景

### DIFF
--- a/src/features/titlebar/TitleBar.tsx
+++ b/src/features/titlebar/TitleBar.tsx
@@ -107,7 +107,7 @@ export function TitleBar() {
         "flex h-11 items-center justify-between px-3 select-none",
         isMac
           ? "bg-background/80 backdrop-blur-sm border-b"
-          : "bg-background"
+          : "relative bg-background"
       )}
     >
       {isMac ? (
@@ -129,19 +129,16 @@ export function TitleBar() {
         </>
       ) : (
         <>
-          {/* Left: filename + actions together (VS Code style) */}
-          <div data-tauri-drag-region className="flex items-center gap-1.5">
+          {/* Center: filename (absolute-centered, ignores left/right width) */}
+          <div data-tauri-drag-region className="absolute inset-x-0 flex items-center justify-center pointer-events-none">
             {fileNameDisplay}
-            {fileName && filePath && (
-              <Separator orientation="vertical" className="mx-0.5 h-5" />
-            )}
-            <div className="flex items-center gap-0.5">
-              {actionButtons}
-            </div>
           </div>
 
-          {/* Right: reserve space for native window controls (min/max/close) */}
-          <div className="w-[140px] shrink-0" />
+          {/* Right: actions + native window controls spacer */}
+          <div className="ml-auto flex items-center gap-0.5">
+            {actionButtons}
+            <div className="w-[140px] shrink-0" />
+          </div>
         </>
       )}
     </div>

--- a/src/features/titlebar/TitleBar.tsx
+++ b/src/features/titlebar/TitleBar.tsx
@@ -63,77 +63,87 @@ export function TitleBar() {
     }
   }, [content, setContent]);
 
+  const fileNameDisplay = fileName ? (
+    <span className={cn("truncate max-w-[300px] text-sm text-muted-foreground", isDirty && "italic")}>
+      {fileName}
+      {isDirty && " *"}
+    </span>
+  ) : null;
+
+  const actionButtons = (
+    <>
+      {filePath && (
+        <>
+          <Tooltip content={t("formatMarkdown")}>
+            <Button variant="ghost" size="icon-sm" onClick={handleFormat}>
+              <WandSparkles className="h-4 w-4" />
+            </Button>
+          </Tooltip>
+          <Tooltip content={modeTooltip}>
+            <Button variant="ghost" size="icon-sm" onClick={toggleEditorMode}>
+              <ModeIcon className="h-4 w-4" />
+            </Button>
+          </Tooltip>
+          <Separator orientation="vertical" className="mx-1 h-5" />
+        </>
+      )}
+      <Tooltip content={t("layout")}>
+        <Button variant="ghost" size="icon-sm" onClick={cycleLayoutMode}>
+          <LayoutIcon className="h-4 w-4" />
+        </Button>
+      </Tooltip>
+      <Tooltip content={t("settings")}>
+        <Button variant="ghost" size="icon-sm" onClick={openSettings}>
+          <Settings className="h-4 w-4" />
+        </Button>
+      </Tooltip>
+    </>
+  );
+
   return (
     <div
       data-tauri-drag-region
-      className="flex h-11 items-center justify-between border-b bg-background/80 backdrop-blur-sm px-3 select-none"
+      className={cn(
+        "flex h-11 items-center justify-between px-3 select-none",
+        isMac
+          ? "bg-background/80 backdrop-blur-sm border-b"
+          : "bg-background"
+      )}
     >
-      {/* Left: macOS traffic light spacer / Windows: nothing */}
-      <div data-tauri-drag-region className="flex items-center gap-1 min-w-[80px]">
-        {isMac && <div className="w-[70px]" />}
-      </div>
+      {isMac ? (
+        <>
+          {/* Left: macOS traffic light spacer */}
+          <div data-tauri-drag-region className="flex items-center gap-1 min-w-[80px]">
+            <div className="w-[70px]" />
+          </div>
 
-      {/* Center: File name */}
-      <div data-tauri-drag-region className="flex items-center gap-2 text-sm text-muted-foreground">
-        {fileName && (
-          <span className={cn("truncate max-w-[300px]", isDirty && "italic")}>
-            {fileName}
-            {isDirty && " *"}
-          </span>
-        )}
-      </div>
+          {/* Center: File name */}
+          <div data-tauri-drag-region className="flex items-center gap-2">
+            {fileNameDisplay}
+          </div>
 
-      {/* Right: Actions + Windows system button spacer */}
-      <div className="flex items-center gap-0.5">
-        {filePath && (
-          <>
-            <Tooltip content={t("formatMarkdown")}>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={handleFormat}
-              >
-                <WandSparkles className="h-4 w-4" />
-              </Button>
-            </Tooltip>
+          {/* Right: Actions */}
+          <div className="flex items-center gap-0.5">
+            {actionButtons}
+          </div>
+        </>
+      ) : (
+        <>
+          {/* Left: filename + actions together (VS Code style) */}
+          <div data-tauri-drag-region className="flex items-center gap-1.5">
+            {fileNameDisplay}
+            {fileName && filePath && (
+              <Separator orientation="vertical" className="mx-0.5 h-5" />
+            )}
+            <div className="flex items-center gap-0.5">
+              {actionButtons}
+            </div>
+          </div>
 
-            <Tooltip content={modeTooltip}>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={toggleEditorMode}
-              >
-                <ModeIcon className="h-4 w-4" />
-              </Button>
-            </Tooltip>
-
-            <Separator orientation="vertical" className="mx-1 h-5" />
-          </>
-        )}
-
-        <Tooltip content={t("layout")}>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={cycleLayoutMode}
-          >
-            <LayoutIcon className="h-4 w-4" />
-          </Button>
-        </Tooltip>
-
-        <Tooltip content={t("settings")}>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={openSettings}
-          >
-            <Settings className="h-4 w-4" />
-          </Button>
-        </Tooltip>
-
-        {/* Windows/Linux: reserve space for native window controls (min/max/close) */}
-        {!isMac && <div className="w-[140px]" />}
-      </div>
+          {/* Right: reserve space for native window controls (min/max/close) */}
+          <div className="w-[140px] shrink-0" />
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #21

- **Windows 布局重构**：文件名居中显示，操作按钮（格式化、模式切换、布局、设置）右对齐，紧贴系统窗口按钮左侧，全部在同一行
- **沉浸式背景**：Windows 标题栏改为 `bg-background`（100% 不透明），移除 `border-b` 分割线，与 app 内容区域颜色完全一致
- **macOS 保持不变**：半透明毛玻璃效果 + 居中文件名布局不受影响

## Test plan

- [ ] Windows 上验证：标题栏颜色与内容区域一致，无白色割裂
- [ ] Windows 上验证：文件名居中，操作按钮右对齐，与系统按钮在同一行
- [ ] macOS 上验证：布局和样式无变化
- [ ] 测试无文件打开时的标题栏显示
- [ ] 测试长文件名的截断效果
- [ ] 验证标题栏空白区域仍可拖拽移动窗口

https://claude.ai/code/session_01R676jf5Hi1KUkyovJjRwL8